### PR TITLE
Fix misc. source comment typos

### DIFF
--- a/qmake/compiler_config.pri
+++ b/qmake/compiler_config.pri
@@ -24,6 +24,6 @@ CONFIG(warn_on) {
 win32-msvc20*:QMAKE_CXXFLAGS *= -wd4996 -wd4290 -wd4503
 win32-msvc*:DEFINES *= BOOST_TYPEOF_SILENT \
                        NOMINMAX \
-# This explicitely defines INTXX_C() and UINTXX_C() macros in <stdint.h> and
+# This explicitly defines INTXX_C() and UINTXX_C() macros in <stdint.h> and
 # also in <boost/cstdint.hpp>
 DEFINES *= __STDC_CONSTANT_MACROS

--- a/src/mathtools/vec_traits.h
+++ b/src/mathtools/vec_traits.h
@@ -119,7 +119,7 @@ struct PointerVecAccessTag : public VecAccessTag { };
 /*! \brief Tag dispatch for vector coordinates to be accessed with a temporary std::array<> object
  *
  *  When none of the other tags can be used, then StdArrayVecAccessTag is the fallback access to
- *  vector coordinates. It has the penality of the creation of a temporary std::array<> object that
+ *  vector coordinates. It has the penalty of the creation of a temporary std::array<> object that
  *  will store the vector coordinates.
  *
  *  Example :

--- a/src/occtools/occ.pri
+++ b/src/occtools/occ.pri
@@ -37,7 +37,7 @@ OCC_VERSION_STR = $$join($$list($$OCC_VERSION_MAJOR, $$OCC_VERSION_MINOR, $$OCC_
 
 message(OCC_VERSION : $$OCC_VERSION_STR)
 
-# Platform dependant config
+# Platform dependent config
 equals(QT_ARCH, i386) {
   ARCH_BITS_SIZE = 32
 } else:equals(QT_ARCH, x86_64) {

--- a/src/occtools/qt_view.cpp
+++ b/src/occtools/qt_view.cpp
@@ -159,7 +159,7 @@ void QtView::Private::initialize()
 /*! \class QtView
  *  \brief Qt wrapper around the V3d_View class
  *
- *  QtView widgets are explicitely bound to a context ie an AIS_InteractiveContext. The context
+ *  QtView widgets are explicitly bound to a context ie an AIS_InteractiveContext. The context
  *  can be retrieved with context().
  *
  *  QtView does not handle input devices interaction like keyboard and mouse.

--- a/src/qttools/core/grid_numbering.cpp
+++ b/src/qttools/core/grid_numbering.cpp
@@ -48,7 +48,7 @@ namespace qttools {
  * \ingroup qttools_core
  *
  * GridNumbering stores key information about numbering of grid cells :
- *    \li start corner (grid corner where the numbering starts, i.e. the firt cell)
+ *    \li start corner (grid corner where the numbering starts, i.e. the first cell)
  *    \li orientation (horizontal or vertical numbering)
  *    \li sweep mode (one-way or zig-zag numbering)
  *

--- a/src/qttools/core/scoped_connection.cpp
+++ b/src/qttools/core/scoped_connection.cpp
@@ -51,7 +51,7 @@ namespace qttools {
  *
  *
  *  ScopedConnect guarantees that a signal/slot connection will get broken when the current scope
- *  dissapears
+ *  disappears
  */
 
 ScopedConnect::ScopedConnect(const QObject* sender, const char* signal,
@@ -79,7 +79,7 @@ ScopedConnect::~ScopedConnect()
  * \ingroup qttools_core
  *
  *  ScopedDisonnect guarantees that a signal/slot connection will get restored when the current
- *  scope dissapears
+ *  scope disappears
  */
 
 ScopedDisconnect::ScopedDisconnect(const QObject* sender, const char* signal,

--- a/src/qttools/gui/item_view_buttons.cpp
+++ b/src/qttools/gui/item_view_buttons.cpp
@@ -242,7 +242,7 @@ void ItemViewButtons::Private::resetButtonUnderMouseState()
  *          pressed down then released while the mouse cursor is inside the button)
  *
  *  \param btnId Identifier of the button clicked (this is the id that was passed to addButton())
- *  \param index Index of the item model where the button click occured
+ *  \param index Index of the item model where the button click occurred
  */
 
 ItemViewButtons::ItemViewButtons(QAbstractItemView* view, QObject *parent)

--- a/src/qttools/gui/item_view_tools.cpp
+++ b/src/qttools/gui/item_view_tools.cpp
@@ -37,7 +37,7 @@
 
 #include "item_view_tools.h"
 
-// Those classe are in Qt4/QtGui and Qt5/QtCore
+// Those classes are in Qt4/QtGui and Qt5/QtCore
 #include <QSortFilterProxyModel>
 #include <QItemSelectionModel>
 

--- a/src/qttools/gui/proxy_styled_item_delegate.cpp
+++ b/src/qttools/gui/proxy_styled_item_delegate.cpp
@@ -43,7 +43,7 @@ namespace qttools {
  * \class ProxyStyledItemDelegate
  * \brief Convenience class that simplifies dynamically overriding QStyledItemDelegate
  *
- * QStyledItemDelegate protected functions cannot be overriden through proxy technique, this is
+ * QStyledItemDelegate protected functions cannot be overridden through proxy technique, this is
  * a limitation that applies to :
  *   \li QStyledItemDelegate::initStyleOption()
  *   \li QStyledItemDelegate::eventFilter()

--- a/src/qttools/gui/strict_stack_widget.cpp
+++ b/src/qttools/gui/strict_stack_widget.cpp
@@ -120,7 +120,7 @@ QWidget *StrictStackWidget::popWidget()
     }
 }
 
-/*! \brief Retruns \c true if the stack contains no widget, otherwise returns \c false
+/*! \brief Returns \c true if the stack contains no widget, otherwise returns \c false
  */
 bool StrictStackWidget::isEmpty() const
 {

--- a/src/qttools/sql/qsql_query_tools.cpp
+++ b/src/qttools/sql/qsql_query_tools.cpp
@@ -70,7 +70,7 @@ QSqlError SqlQueryError::sqlError() const
     return m_sqlError;
 }
 
-/*! \brief Execute SQL statements in \p code use databse connection \p db
+/*! \brief Execute SQL statements in \p code use database connection \p db
  *  \note Does nothing if \p sqlCode is empty
  *  \throws SqlQueryError if no connection to database or if SQL exec fails (SQL query has error)
  */
@@ -91,7 +91,7 @@ QSqlQuery execSqlCode(const QString& sqlCode, const QSqlDatabase& db)
 }
 
 /*! \brief Same as qttools::execSqlCode() but execution performs inside a transaction
- *  \note Any SqlQueryError exceptions thrown by qttools::execSqlCode() is catched (transaction
+ *  \note Any SqlQueryError exceptions thrown by qttools::execSqlCode() is caught (transaction
  *        is rolled back then)
  */
 QSqlQuery execSqlCodeInTransaction(const QString& sqlCode, QSqlDatabase db)


### PR DESCRIPTION
Found via `codespell -q 3 -L numer,pres`